### PR TITLE
Add parent patcher navigation and fix large patch handling

### DIFF
--- a/MaxMSP_Agent/max_mcp.js
+++ b/MaxMSP_Agent/max_mcp.js
@@ -182,6 +182,9 @@ function anything() {
         case "exit_subpatcher":
             exit_subpatcher();
             break;
+        case "enter_parent_patcher":
+            enter_parent_patcher();
+            break;
         case "get_patcher_context":
             if (data.request_id) {
                 get_patcher_context(data.request_id);
@@ -679,6 +682,27 @@ function exit_subpatcher() {
     avoid_rect_called = false;
 
     post("Exited to parent patcher (depth: " + patcher_stack.length + ")\n");
+}
+
+function enter_parent_patcher() {
+    var parent = current_patcher.parentpatcher;
+    if (!parent) {
+        post("No parent patcher available - already at top level\n");
+        return;
+    }
+
+    // Push current context onto stack so we can return with exit_subpatcher
+    patcher_stack.push({
+        patcher: current_patcher,
+        name: "_parent"
+    });
+
+    current_patcher = parent;
+
+    // Reset preflight check
+    avoid_rect_called = false;
+
+    post("Entered parent patcher (depth: " + patcher_stack.length + ")\n");
 }
 
 function get_patcher_context(request_id) {

--- a/MaxMSP_Agent/max_mcp.js
+++ b/MaxMSP_Agent/max_mcp.js
@@ -666,6 +666,9 @@ function enter_subpatcher(var_name) {
     // Reset preflight check - new context requires new avoid rect check
     avoid_rect_called = false;
 
+    // Sync V8 add-on navigation
+    outlet(2, "nav_enter_subpatcher", var_name);
+
     post("Entered subpatcher: " + var_name + " (depth: " + patcher_stack.length + ")\n");
 }
 
@@ -680,6 +683,9 @@ function exit_subpatcher() {
 
     // Reset preflight check - returning to parent context requires new avoid rect check
     avoid_rect_called = false;
+
+    // Sync V8 add-on navigation
+    outlet(2, "nav_exit_subpatcher");
 
     post("Exited to parent patcher (depth: " + patcher_stack.length + ")\n");
 }
@@ -701,6 +707,9 @@ function enter_parent_patcher() {
 
     // Reset preflight check
     avoid_rect_called = false;
+
+    // Sync V8 add-on navigation
+    outlet(2, "nav_enter_parent");
 
     post("Entered parent patcher (depth: " + patcher_stack.length + ")\n");
 }

--- a/MaxMSP_Agent/max_mcp.js
+++ b/MaxMSP_Agent/max_mcp.js
@@ -1,7 +1,11 @@
 
 autowatch = 1; // 1
-inlets = 1; // Receive network messages here
+inlets = 2; // inlet 0: network messages; inlet 1: [console] output (packed list: source, text, type)
 outlets = 3; // For status, responses, etc.
+
+// Console ring buffer — accumulates Max console messages in real-time
+var CONSOLE_BUFFER_MAX = 10000;
+var console_buffer = []; // each entry: {s: source, t: text, tp: type}
 
 // Subpatcher navigation state
 var root_patcher = this.patcher;
@@ -72,6 +76,20 @@ function check_large_patch_warning() {
 
 // Called when a message arrives at inlet 0 (from [udpreceive] or similar)
 function anything() {
+    // Inlet 1: console messages from [pack s s 0]
+    // [pack s s 0] output starts with a symbol, so Max JS routes it here as
+    // an "anything" message where messagename = source, arguments = [text, type]
+    if (this.inlet === 1) {
+        var source = messagename;
+        var text = String(arguments[0] || "");
+        var type = arguments[1] || 0;
+        console_buffer.push({s: source, t: text, tp: type});
+        if (console_buffer.length > CONSOLE_BUFFER_MAX) {
+            console_buffer.shift();
+        }
+        return;
+    }
+
     var msg = arrayfromargs(messagename, arguments).join(" ");
     var data = safe_parse_json(msg);
     if (!data) return;
@@ -197,6 +215,27 @@ function anything() {
                 switch_to_patcher(data.request_id, data.patcher_name);
             } else {
                 outlet(0, "error", "Missing request_id or patcher_name for switch_to_patcher");
+            }
+            break;
+        case "get_max_console":
+            if (data.request_id) {
+                get_max_console(data.request_id, data.lines || 100);
+            } else {
+                outlet(0, "error", "Missing request_id for get_max_console");
+            }
+            break;
+        case "clear_max_console":
+            if (data.request_id) {
+                clear_max_console(data.request_id);
+            } else {
+                outlet(0, "error", "Missing request_id for clear_max_console");
+            }
+            break;
+        case "clear_console_buffer":
+            if (data.request_id) {
+                clear_console_buffer(data.request_id);
+            } else {
+                outlet(0, "error", "Missing request_id for clear_console_buffer");
             }
             break;
         case "get_patcher_context":
@@ -838,6 +877,62 @@ function switch_to_patcher(request_id, patcher_name) {
         "success": true,
         "name": found.name,
         "filepath": found.filepath || "(unsaved)"
+    }};
+    outlet(1, "response", JSON.stringify(result, null, 0));
+}
+
+var CONSOLE_MISSING_ERROR = "[console] object not found. Paste the snippet below into Max, then connect [pack s s 0] output to [js] inlet 1, and reload:\n----------begin_max5_patcher----------\n381.3ocyT91aBBCDF+89onoulsPgglsuJFioVu3pCZIsEGFie2Wuh+AyXLXK\nyLR.JWeN5C+n2cXBwePWoqAK8Ex7vi3wgKiNKvO8sACSTvqE4bKlLUAuqWsk\nF8YUNn1gJbZ69hU57tzTxchWkpMKMf.EOmjLK4w3HBaVLdKaFdMwGhrnizUU\nERUN3Pmv5ddckqGAx0nC8e.OvR6xeMY61WBAyQojE2H53kmNF8GiwRt3MhWi\nGTjBvZ4a.R7.YJaZ.iwYAzlxFLTS+cP84+oLcG2n3E35SKDkKEZkUmC8Q+dj\n7k7lkNcr79a2Dm1KuyFDuiZNkJWOnOL5jco4RU+sJBL.U08eEqtxHNs7mK1H\ncSi0f0IUbmTqtp2uOhv9AaSFosxZVlg5pyeE2CaMRXcmbUx3bUx.2twKK2AF\naS9Wshu3dq13C8bTqXRUHVRqXFXm7T1wsByM95TmuHsxDJ8qm9Ds8aRuFLpJ\nIVFNoEpngFJX+BquGbHSr8yjieP1I63J\n-----------end_max5_patcher-----------";
+
+function get_max_console(request_id, lines) {
+    if (console_buffer.length === 0) {
+        // Check if the [console] object is missing (likely not wired up yet)
+        var consoleObj = this.patcher.getnamed("mcp_console");
+        if (!consoleObj) {
+            var result = {"request_id": request_id, "results": {"error": CONSOLE_MISSING_ERROR}};
+            outlet(1, "response", JSON.stringify(result, null, 0));
+            return;
+        }
+    }
+
+    var tail = console_buffer.slice(-lines);
+    var lines_out = [];
+    for (var i = 0; i < tail.length; i++) {
+        lines_out.push(tail[i].s + ": " + tail[i].t);
+    }
+
+    var result = {"request_id": request_id, "results": {
+        "total_buffered": console_buffer.length,
+        "returned_lines": tail.length,
+        "content": lines_out.join("\n")
+    }};
+    outlet(1, "response", JSON.stringify(result, null, 0));
+}
+
+function clear_max_console(request_id) {
+    // Clears the visual Max console only — ring buffer is preserved
+    var consoleObj = this.patcher.getnamed("mcp_console");
+    if (!consoleObj) {
+        var result = {"request_id": request_id, "results": {"error": CONSOLE_MISSING_ERROR}};
+        outlet(1, "response", JSON.stringify(result, null, 0));
+        return;
+    }
+
+    consoleObj.message("clear");
+
+    var result = {"request_id": request_id, "results": {
+        "success": true,
+        "note": "Visual console cleared. Ring buffer intact (" + console_buffer.length + " entries)."
+    }};
+    outlet(1, "response", JSON.stringify(result, null, 0));
+}
+
+function clear_console_buffer(request_id) {
+    // Clears the JS ring buffer only — visual console unchanged
+    var cleared = console_buffer.length;
+    console_buffer = [];
+    var result = {"request_id": request_id, "results": {
+        "success": true,
+        "cleared_entries": cleared
     }};
     outlet(1, "response", JSON.stringify(result, null, 0));
 }

--- a/MaxMSP_Agent/max_mcp.js
+++ b/MaxMSP_Agent/max_mcp.js
@@ -185,6 +185,20 @@ function anything() {
         case "enter_parent_patcher":
             enter_parent_patcher();
             break;
+        case "list_open_patchers":
+            if (data.request_id) {
+                list_open_patchers(data.request_id);
+            } else {
+                outlet(0, "error", "Missing request_id for list_open_patchers");
+            }
+            break;
+        case "switch_to_patcher":
+            if (data.request_id && data.patcher_name !== undefined) {
+                switch_to_patcher(data.request_id, data.patcher_name);
+            } else {
+                outlet(0, "error", "Missing request_id or patcher_name for switch_to_patcher");
+            }
+            break;
         case "get_patcher_context":
             if (data.request_id) {
                 get_patcher_context(data.request_id);
@@ -712,6 +726,121 @@ function enter_parent_patcher() {
     outlet(2, "nav_enter_parent");
 
     post("Entered parent patcher (depth: " + patcher_stack.length + ")\n");
+}
+
+function find_any_wind() {
+    // Strategy 1: max.frontpatcher (works when Max is active app)
+    var fp = max.frontpatcher;
+    if (fp && fp.wind) return fp.wind;
+
+    // Strategy 2: climb to the TOP-MOST patcher (not just first with a window)
+    // The topmost patcher's window is at the start of the global wind chain
+    var p = this.patcher;
+    var topmost_with_wind = null;
+    while (p) {
+        if (p.wind) topmost_with_wind = p;
+        p = p.parentpatcher;
+    }
+    if (topmost_with_wind) return topmost_with_wind.wind;
+
+    // Strategy 3: try current_patcher
+    if (current_patcher && current_patcher.wind) return current_patcher.wind;
+
+    return null;
+}
+
+function collect_wind_patchers(w, direction, seen, patchers, start_w) {
+    // Walk the wind chain in a given direction ("next" or "prev")
+    while (w) {
+        var p = w.assoc;
+        if (p && !seen[p.name + "|" + p.filepath]) {
+            seen[p.name + "|" + p.filepath] = true;
+            patchers.push({
+                patcher: p,
+                name: p.name || "(unnamed)",
+                filepath: p.filepath || "(unsaved)",
+                is_current: (p === current_patcher)
+            });
+        }
+        w = w[direction];
+        if (!w || w === start_w) break;  // end of list or circular
+    }
+}
+
+function collect_all_patchers() {
+    var patchers = [];
+    var w = find_any_wind();
+
+    if (w) {
+        var seen = {};
+        var start_w = w;
+
+        // Walk forward from starting window
+        collect_wind_patchers(w, "next", seen, patchers, start_w);
+
+        // Walk backward too (wind list may be linear, not circular)
+        var prev_w = start_w.prev;
+        if (prev_w) {
+            collect_wind_patchers(prev_w, "prev", seen, patchers, start_w);
+        }
+    }
+
+    return patchers;
+}
+
+function list_open_patchers(request_id) {
+    var all = collect_all_patchers();
+    // Strip patcher references for JSON output
+    var patchers = [];
+    for (var i = 0; i < all.length; i++) {
+        patchers.push({
+            name: all[i].name,
+            filepath: all[i].filepath,
+            is_current: all[i].is_current
+        });
+    }
+    var results = {"request_id": request_id, "results": patchers};
+    outlet(1, "response", JSON.stringify(results, null, 0));
+}
+
+function switch_to_patcher(request_id, patcher_name) {
+    var all = collect_all_patchers();
+    var found = null;
+
+    for (var i = 0; i < all.length; i++) {
+        if (all[i].name === patcher_name || all[i].filepath === patcher_name) {
+            found = all[i].patcher;
+            break;
+        }
+    }
+
+    if (!found) {
+        var result = {"request_id": request_id, "results": {
+            "success": false,
+            "error": "Patcher not found: " + patcher_name
+        }};
+        outlet(1, "response", JSON.stringify(result, null, 0));
+        return;
+    }
+
+    // Reset navigation stack and set new current patcher
+    patcher_stack = [];
+    current_patcher = found;
+
+    // Reset preflight check
+    avoid_rect_called = false;
+
+    // Sync V8 add-on
+    outlet(2, "nav_switch_to_patcher", patcher_name);
+
+    post("Switched to patcher: " + found.name + "\n");
+
+    var result = {"request_id": request_id, "results": {
+        "success": true,
+        "name": found.name,
+        "filepath": found.filepath || "(unsaved)"
+    }};
+    outlet(1, "response", JSON.stringify(result, null, 0));
 }
 
 function get_patcher_context(request_id) {

--- a/MaxMSP_Agent/max_mcp.js
+++ b/MaxMSP_Agent/max_mcp.js
@@ -1023,42 +1023,36 @@ function send_chunked_to_v8(action, request_id, json_str) {
 }
 
 function collect_objects(obj) {
-    //var keys = Object.keys(obj.varname);
-    //post(typeof obj.varname + "\n");
-    if (obj.varname.substring(0, 8) == "maxmcpid"){
+    // Use getattr() for safer null handling in Max 9 / M4L context
+    var varname = obj.getattr("varname");
+    if (varname && String(varname).substring(0, 8) === "maxmcpid") {
         return;
     }
-    if (!obj.varname){
-        obj.varname = "obj-" + obj_count;
+    if (!varname) {
+        varname = "obj-" + obj_count;
+        obj.varname = varname;
     }
-    obj_count+=1;
+    obj_count += 1;
 
-    var outputs = obj.patchcords.outputs;
-    if (outputs.length){
-        for (var i = 0; i < outputs.length; i++) {
-            lines.push({patchline: {
-                source: [obj.varname, outputs[i].srcoutlet],
-                destination: [outputs[i].dstobject.varname, outputs[i].dstinlet]
-            }})
-        }
+    var patchcords = obj.patchcords;
+    var outputs = (patchcords && patchcords.outputs) ? patchcords.outputs : [];
+    for (var i = 0; i < outputs.length; i++) {
+        var out = outputs[i];
+        // Guard against null dstobject (can crash in Max 9 M4L if destination is invalid)
+        if (!out || !out.dstobject) continue;
+        var dstname = out.dstobject.getattr("varname");
+        if (!dstname) continue;
+        lines.push({patchline: {
+            source: [varname, out.srcoutlet],
+            destination: [dstname, out.dstinlet]
+        }});
     }
-    var attrnames = obj.getattrnames();
-    var attr = {};
-    if (attrnames.length){
-        for (var i = 0; i < attrnames.length; i++) {
-            var name = attrnames[i];
-            var value = obj.getattr(name);
-            attr[name] = value;
-        }
-    }
-    boxes.push({box:{
-        maxclass: obj.maxclass,
-        varname: obj.varname,
+
+    boxes.push({box: {
+        maxclass: obj.getattr("maxclass") || obj.maxclass,
+        varname: varname,
         patching_rect: obj.rect,
-        // numinlets: obj.patchcords.inputs.length,
-        // numoutputs: obj.patchcords.outputs.length,
-        // attributes: attr,
-    }})
+    }});
 }
 
 function get_object_attributes(request_id, var_name) {

--- a/MaxMSP_Agent/max_mcp.js
+++ b/MaxMSP_Agent/max_mcp.js
@@ -729,28 +729,42 @@ function enter_parent_patcher() {
 }
 
 function find_any_wind() {
-    // Strategy 1: max.frontpatcher (works when Max is active app)
-    var fp = max.frontpatcher;
-    if (fp && fp.wind) return fp.wind;
+    // The wind chain is a global front-to-back list of all open windows.
+    // Entry point is max.frontpatcher.wind, but it returns null when Max
+    // isn't the active app. Fix: bring our own window to front first,
+    // then send it back to restore the user's window ordering.
 
-    // Strategy 2: climb to the TOP-MOST patcher (not just first with a window)
-    // The topmost patcher's window is at the start of the global wind chain
+    var fp = max.frontpatcher;
+    if (fp && fp.wind) return { wind: fp.wind, pushed: null };
+
+    // max.frontpatcher failed (Max not active app) — bring our window to front
     var p = this.patcher;
     var topmost_with_wind = null;
     while (p) {
         if (p.wind) topmost_with_wind = p;
         p = p.parentpatcher;
     }
-    if (topmost_with_wind) return topmost_with_wind.wind;
+    if (topmost_with_wind && topmost_with_wind.wind) {
+        topmost_with_wind.wind.bringtofront();
+        fp = max.frontpatcher;
+        if (fp && fp.wind) return { wind: fp.wind, pushed: topmost_with_wind.wind };
+        return { wind: topmost_with_wind.wind, pushed: topmost_with_wind.wind };
+    }
 
-    // Strategy 3: try current_patcher
-    if (current_patcher && current_patcher.wind) return current_patcher.wind;
+    if (current_patcher && current_patcher.wind)
+        return { wind: current_patcher.wind, pushed: null };
 
     return null;
 }
 
-function collect_wind_patchers(w, direction, seen, patchers, start_w) {
-    // Walk the wind chain in a given direction ("next" or "prev")
+function collect_all_patchers() {
+    var patchers = [];
+    var seen = {};
+    var result = find_any_wind();
+    if (!result) return patchers;
+
+    // wind.next is a global front-to-back chain of all open windows.
+    var w = result.wind;
     while (w) {
         var p = w.assoc;
         if (p && !seen[p.name + "|" + p.filepath]) {
@@ -762,27 +776,12 @@ function collect_wind_patchers(w, direction, seen, patchers, start_w) {
                 is_current: (p === current_patcher)
             });
         }
-        w = w[direction];
-        if (!w || w === start_w) break;  // end of list or circular
+        w = w.next;
     }
-}
 
-function collect_all_patchers() {
-    var patchers = [];
-    var w = find_any_wind();
-
-    if (w) {
-        var seen = {};
-        var start_w = w;
-
-        // Walk forward from starting window
-        collect_wind_patchers(w, "next", seen, patchers, start_w);
-
-        // Walk backward too (wind list may be linear, not circular)
-        var prev_w = start_w.prev;
-        if (prev_w) {
-            collect_wind_patchers(prev_w, "prev", seen, patchers, start_w);
-        }
+    // Restore window ordering if we pushed our window to front
+    if (result.pushed) {
+        result.pushed.sendtoback();
     }
 
     return patchers;

--- a/MaxMSP_Agent/max_mcp_v8_add_on.js
+++ b/MaxMSP_Agent/max_mcp_v8_add_on.js
@@ -141,50 +141,43 @@ function nav_exit_subpatcher() {
 
 function v8_find_any_wind() {
     var fp = max.frontpatcher;
-    if (fp && fp.wind) return fp.wind;
+    if (fp && fp.wind) return { wind: fp.wind, pushed: null };
 
-    // Climb to TOPMOST parent with a window (not first)
-    // The topmost patcher's window is at the start of the global wind chain
     var p = this.patcher;
     var topmost_with_wind = null;
     while (p) {
         if (p.wind) topmost_with_wind = p;
         p = p.parentpatcher;
     }
-    if (topmost_with_wind) return topmost_with_wind.wind;
+    if (topmost_with_wind && topmost_with_wind.wind) {
+        topmost_with_wind.wind.bringtofront();
+        fp = max.frontpatcher;
+        if (fp && fp.wind) return { wind: fp.wind, pushed: topmost_with_wind.wind };
+        return { wind: topmost_with_wind.wind, pushed: topmost_with_wind.wind };
+    }
 
-    if (current_patcher && current_patcher.wind) return current_patcher.wind;
+    if (current_patcher && current_patcher.wind)
+        return { wind: current_patcher.wind, pushed: null };
     return null;
 }
 
 function v8_find_patcher_by_name(patcher_name) {
-    var w = v8_find_any_wind();
-    if (!w) return null;
+    var result = v8_find_any_wind();
+    if (!result) return null;
 
-    var start_w = w;
-
-    // Walk forward
+    var w = result.wind;
+    var found = null;
     while (w) {
         var p = w.assoc;
         if (p && (p.name === patcher_name || p.filepath === patcher_name)) {
-            return p;
+            found = p;
+            break;
         }
         w = w.next;
-        if (!w || w === start_w) break;
     }
 
-    // Walk backward (wind list may be linear)
-    w = start_w.prev;
-    while (w) {
-        var p = w.assoc;
-        if (p && (p.name === patcher_name || p.filepath === patcher_name)) {
-            return p;
-        }
-        w = w.prev;
-        if (!w || w === start_w) break;
-    }
-
-    return null;
+    if (result.pushed) result.pushed.sendtoback();
+    return found;
 }
 
 function nav_switch_to_patcher(patcher_name) {

--- a/MaxMSP_Agent/max_mcp_v8_add_on.js
+++ b/MaxMSP_Agent/max_mcp_v8_add_on.js
@@ -89,6 +89,11 @@ function anything() {
         case "nav_exit_subpatcher":
             nav_exit_subpatcher();
             break;
+        case "nav_switch_to_patcher":
+            if (arguments.length >= 1) {
+                nav_switch_to_patcher(arguments[0]);
+            }
+            break;
         default:
             // outlet(1, messagename, ...arguments);
             outlet(1, "response", arguments[1]);
@@ -132,6 +137,66 @@ function nav_exit_subpatcher() {
     }
     current_patcher = patcher_stack.pop();
     post("v8: Exited to parent (depth: " + patcher_stack.length + ")\n");
+}
+
+function v8_find_any_wind() {
+    var fp = max.frontpatcher;
+    if (fp && fp.wind) return fp.wind;
+
+    // Climb to TOPMOST parent with a window (not first)
+    // The topmost patcher's window is at the start of the global wind chain
+    var p = this.patcher;
+    var topmost_with_wind = null;
+    while (p) {
+        if (p.wind) topmost_with_wind = p;
+        p = p.parentpatcher;
+    }
+    if (topmost_with_wind) return topmost_with_wind.wind;
+
+    if (current_patcher && current_patcher.wind) return current_patcher.wind;
+    return null;
+}
+
+function v8_find_patcher_by_name(patcher_name) {
+    var w = v8_find_any_wind();
+    if (!w) return null;
+
+    var start_w = w;
+
+    // Walk forward
+    while (w) {
+        var p = w.assoc;
+        if (p && (p.name === patcher_name || p.filepath === patcher_name)) {
+            return p;
+        }
+        w = w.next;
+        if (!w || w === start_w) break;
+    }
+
+    // Walk backward (wind list may be linear)
+    w = start_w.prev;
+    while (w) {
+        var p = w.assoc;
+        if (p && (p.name === patcher_name || p.filepath === patcher_name)) {
+            return p;
+        }
+        w = w.prev;
+        if (!w || w === start_w) break;
+    }
+
+    return null;
+}
+
+function nav_switch_to_patcher(patcher_name) {
+    var found = v8_find_patcher_by_name(patcher_name);
+
+    if (found) {
+        patcher_stack = [];
+        current_patcher = found;
+        post("v8: Switched to patcher: " + found.name + "\n");
+    } else {
+        post("v8: Patcher not found: " + patcher_name + "\n");
+    }
 }
 
 // ========================================

--- a/MaxMSP_Agent/max_mcp_v8_add_on.js
+++ b/MaxMSP_Agent/max_mcp_v8_add_on.js
@@ -3,6 +3,10 @@ autowatch = 1; // 1
 inlets = 1; // Receive network messages here
 outlets = 2; // For status, responses, etc.
 
+// Patcher navigation state (mirrors max_mcp.js)
+var current_patcher = this.patcher;
+var patcher_stack = [];
+
 function safe_parse_json(str) {
     try {
         return JSON.parse(str);
@@ -74,11 +78,63 @@ function anything() {
             }
             complete_signal_safety(arguments[0]);
             break;
+        case "nav_enter_parent":
+            nav_enter_parent();
+            break;
+        case "nav_enter_subpatcher":
+            if (arguments.length >= 1) {
+                nav_enter_subpatcher(arguments[0]);
+            }
+            break;
+        case "nav_exit_subpatcher":
+            nav_exit_subpatcher();
+            break;
         default:
             // outlet(1, messagename, ...arguments);
             outlet(1, "response", arguments[1]);
     }
 }
+
+// ========================================
+// Patcher navigation (mirrors max_mcp.js state):
+
+function nav_enter_parent() {
+    var parent = current_patcher.parentpatcher;
+    if (!parent) {
+        post("v8: No parent patcher available\n");
+        return;
+    }
+    patcher_stack.push(current_patcher);
+    current_patcher = parent;
+    post("v8: Entered parent patcher (depth: " + patcher_stack.length + ")\n");
+}
+
+function nav_enter_subpatcher(var_name) {
+    var obj = current_patcher.getnamed(var_name);
+    if (!obj) {
+        post("v8: Object not found: " + var_name + "\n");
+        return;
+    }
+    var subpatch = obj.subpatcher();
+    if (!subpatch) {
+        post("v8: Not a subpatcher: " + var_name + "\n");
+        return;
+    }
+    patcher_stack.push(current_patcher);
+    current_patcher = subpatch;
+    post("v8: Entered subpatcher: " + var_name + " (depth: " + patcher_stack.length + ")\n");
+}
+
+function nav_exit_subpatcher() {
+    if (patcher_stack.length === 0) {
+        post("v8: Already at root\n");
+        return;
+    }
+    current_patcher = patcher_stack.pop();
+    post("v8: Exited to parent (depth: " + patcher_stack.length + ")\n");
+}
+
+// ========================================
 
 function add_boxtext(request_id, data){
     var patcher_dict = safe_parse_json(data);
@@ -88,7 +144,7 @@ function add_boxtext(request_id, data){
         outlet(1, "response", JSON.stringify(result));
         return;
     }
-    var p = this.patcher;
+    var p = current_patcher;
 
     patcher_dict.boxes.forEach(function (b) {
         var obj = p.getnamed(b.box.varname);
@@ -131,7 +187,7 @@ function complete_signal_safety(data_str) {
     var data = safe_parse_json(data_str);
     if (!data) return;
 
-    var p = this.patcher;
+    var p = current_patcher;
     var request_id = data.request_id;
     var warnings = data.warnings || [];
     var objects_to_check = data.objects_to_check || [];
@@ -261,7 +317,7 @@ function complete_encapsulate(data_str) {
     var data = safe_parse_json(data_str);
     if (!data) return;
 
-    var p = this.patcher;
+    var p = current_patcher;
     var request_id = data.request_id;
     var subpatcher_varname = data.subpatcher_varname;
     var objects_info = data.objects_info;
@@ -465,7 +521,7 @@ function complete_encapsulate(data_str) {
 }
 
 function autofit_v8(var_name) {
-    var p = this.patcher;
+    var p = current_patcher;
     var obj = p.getnamed(var_name);
 
     if (!obj) {

--- a/server.py
+++ b/server.py
@@ -763,6 +763,21 @@ async def exit_subpatcher(ctx: Context):
 
 
 @mcp.tool()
+async def enter_parent_patcher(ctx: Context):
+    """Navigate up to the parent patcher that contains the current patcher.
+
+    This uses Max's parentpatcher API to go above the root level,
+    which is useful when the MCP agent runs inside an abstraction
+    and you need to operate on the parent patch that contains it.
+
+    Use exit_subpatcher to return back down.
+    """
+    maxmsp = ctx.request_context.lifespan_context.get("maxmsp")
+    cmd = {"action": "enter_parent_patcher"}
+    await maxmsp.send_command(cmd)
+
+
+@mcp.tool()
 async def get_patcher_context(ctx: Context):
     """Get information about the current patcher navigation context.
 

--- a/server.py
+++ b/server.py
@@ -815,6 +815,63 @@ async def switch_to_patcher(ctx: Context, patcher_name: str):
 
 
 @mcp.tool()
+async def get_max_console(ctx: Context, lines: int = 100):
+    """Read the Max console output from the internal ring buffer.
+
+    The ring buffer accumulates all Max console messages in real-time as they
+    arrive (post(), object errors, warnings, manual actions — everything).
+    Buffer holds up to 10000 entries, older ones are dropped. Buffer persists
+    even after clear_max_console.
+
+    Does NOT clear anything — use clear_max_console or clear_console_buffer.
+
+    Args:
+        lines (int): Number of most recent lines to return (default 100).
+
+    Returns:
+        dict: total_buffered, returned_lines, and content (formatted log text).
+    """
+    maxmsp = ctx.request_context.lifespan_context.get("maxmsp")
+    payload = {"action": "get_max_console", "lines": lines}
+    response = await maxmsp.send_request(payload)
+    return response
+
+
+@mcp.tool()
+async def clear_max_console(ctx: Context):
+    """Clear the visual Max console window only.
+
+    The internal ring buffer is NOT cleared — older messages remain accessible
+    via get_max_console even after this call. Use clear_console_buffer to also
+    wipe the ring buffer.
+
+    Returns:
+        dict: Success status and current ring buffer entry count.
+    """
+    maxmsp = ctx.request_context.lifespan_context.get("maxmsp")
+    payload = {"action": "clear_max_console"}
+    response = await maxmsp.send_request(payload)
+    return response
+
+
+@mcp.tool()
+async def clear_console_buffer(ctx: Context):
+    """Clear the internal Max console ring buffer.
+
+    The visual Max console window is NOT affected. Use this to start fresh
+    with the AI's accumulated message history (e.g. beginning a new debug
+    session). Reports how many entries were cleared.
+
+    Returns:
+        dict: Success status and number of cleared entries.
+    """
+    maxmsp = ctx.request_context.lifespan_context.get("maxmsp")
+    payload = {"action": "clear_console_buffer"}
+    response = await maxmsp.send_request(payload)
+    return response
+
+
+@mcp.tool()
 async def get_patcher_context(ctx: Context):
     """Get information about the current patcher navigation context.
 

--- a/server.py
+++ b/server.py
@@ -778,6 +778,43 @@ async def enter_parent_patcher(ctx: Context):
 
 
 @mcp.tool()
+async def list_open_patchers(ctx: Context):
+    """List all open patcher windows in the Max application.
+
+    Returns name, filepath, and whether each patcher is the current context.
+    Use switch_to_patcher to navigate to any listed patcher.
+
+    Returns:
+        list: List of open patchers with name, filepath, and is_current flag.
+    """
+    maxmsp = ctx.request_context.lifespan_context.get("maxmsp")
+    payload = {"action": "list_open_patchers"}
+    response = await maxmsp.send_request(payload)
+    return response
+
+
+@mcp.tool()
+async def switch_to_patcher(ctx: Context, patcher_name: str):
+    """Switch the MCP context to any open patcher window by name or filepath.
+
+    This allows operating on any patcher open in Max, not just the parent
+    of the MCP abstraction. Use list_open_patchers to see available patchers.
+
+    The navigation stack is reset when switching patchers.
+
+    Args:
+        patcher_name (str): The name or filepath of the patcher to switch to.
+
+    Returns:
+        dict: Success status with patcher name and filepath.
+    """
+    maxmsp = ctx.request_context.lifespan_context.get("maxmsp")
+    payload = {"action": "switch_to_patcher", "patcher_name": patcher_name}
+    response = await maxmsp.send_request(payload)
+    return response
+
+
+@mcp.tool()
 async def get_patcher_context(ctx: Context):
     """Get information about the current patcher navigation context.
 


### PR DESCRIPTION
  Two independent improvements to the MCP agent:

  - enter_parent_patcher() tool — When the MCP agent runs inside an abstraction, this.patcher refers to the abstraction's own patcher, not the
   user's patch. This new tool uses Max's parentpatcher API to navigate up to the containing patch, allowing objects to be created and
  inspected there. The existing exit_subpatcher() is used to navigate back down.
  - Fix get_objects_in_patch failing on patches with many objects — Max silently truncates symbols at 32767 characters. When a patch's JSON
  representation exceeds this limit, the string sent from js to v8 via outlet gets truncated, causing JSON.parse to fail. This is fixed by
  chunking large JSON strings (>16KB) into multiple messages using a start/chunk/end protocol between max_mcp.js and the v8 add-on. A
  null-guard in add_boxtext is also added to return a proper error instead of crashing on parse failure.