### PR TITLE
Ensure default configuration for mcpServers in config

### DIFF
--- a/install.py
+++ b/install.py
@@ -54,6 +54,7 @@ def main():
 
     mcp_name = "mcpServers" if args.client != "vscode" else "servers"
 
+    config_data.setdefault(mcp_name, {})
     config_data[mcp_name]["MaxMSPMCP"] = {
         "command": "mcp",
         "args": ["run", os.path.join(current_dir, "server.py")],


### PR DESCRIPTION
The install script fails if the config doesn't already contain an MCP servers key/value. This patch ensures it exists before adding the MaxMSPCP server.